### PR TITLE
Target screen support and overlay coordinate fixes

### DIFF
--- a/src/tiinyswatch/app.py
+++ b/src/tiinyswatch/app.py
@@ -125,11 +125,11 @@ class App(QMainWindow):
 
     def toggleColorPick(self) -> None:
         """Start the color picking process."""
-        screen = QGuiApplication.primaryScreen()
-        screenshot = screen.grabWindow(0).toImage()
+        screen = QGuiApplication.screenAt(QCursor.pos()) or QGuiApplication.primaryScreen()
+        screenshot = screen.grabWindow(0)
         
         if not self.overlay:
-            self.overlay = TransparentOverlay(self, screenshot)
+            self.overlay = TransparentOverlay(self, screenshot, target_screen=screen)
             self.overlay.show()
             self.overlayToggled = True
         else:


### PR DESCRIPTION
Use QGuiApplication.screenAt to pick the active screen and pass it to TransparentOverlay. Make the overlay use the target screen's geometry instead of forcing fullscreen. Unify handling of physical/logical coordinates by tracking positions in physical pixels and adding helpers (getEventUpscaledCursorPosition, getGlobalUpscaledCursorPosition, physicalToLocalLogical, roundedPoint, inclusiveRectFromPoints). Fix selection averaging and zoom rendering by using inclusive selection rectangles, iterating inclusive ranges, and computing scaled highlight/selection rects consistently with devicePixelRatio.